### PR TITLE
USC-1797 Change signature for deleteEntry

### DIFF
--- a/androidkeystore.cpp
+++ b/androidkeystore.cpp
@@ -113,7 +113,7 @@ bool KeyStore::containsAlias(const QString &alias) const
 
 bool KeyStore::deleteEntry(const QString &alias) const
 {
-    callMethod<void>("deleteEntry", "(Ljava/lang/String;)Z", fromString(alias).object());
+    callMethod<void>("deleteEntry", "(Ljava/lang/String;)V", fromString(alias).object());
     return handleExceptions();
 }
 


### PR DESCRIPTION
deleteEntry is a void method and does not return a boolean.
https://developer.android.com/reference/java/security/KeyStore.html#deleteEntry(java.lang.String)