### PR TITLE
Usc 1928 built for newer i os version than being linked

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ if (Qt5Core_FOUND)
   include_directories(${Qt5Core_INCLUDE_DIRS})
   
   message("Bob!!!")
+  message("TBDkgr...testing")
   message("Qt5core lib ${Qt5Core_LIBRARIES}")
   message("Qt5core inc ${Qt5Core_INCLUDE_DIRS}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,6 @@ if (Qt5Core_FOUND)
   include_directories(${Qt5Core_INCLUDE_DIRS})
   
   message("Bob!!!")
-  message("TBDkgr...testing")
   message("Qt5core lib ${Qt5Core_LIBRARIES}")
   message("Qt5core inc ${Qt5Core_INCLUDE_DIRS}")
 

--- a/cmake/iOS.cmake
+++ b/cmake/iOS.cmake
@@ -36,7 +36,7 @@ set (APPLE True)
 set (IOS True)
 
 # Required as of cmake 2.8.10
-set (CMAKE_OSX_DEPLOYMENT_TARGET "" CACHE STRING "Force unset of the deployment target for iOS" FORCE)
+set (CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "Set earliest deployment version for iOS" FORCE)
 
 # Determine the cmake host system version so we know where to find the iOS SDKs
 find_program (CMAKE_UNAME uname /bin /usr/bin /usr/local/bin)


### PR DESCRIPTION
See also USC-1928 Remove 3rd party warnings.

* Issue: link warning
E.g. ld: warning: object file (/Users/ext_bpl/kogr/unified-sense-client/packages/qtkeychain/libqt5keychain_ios.a(keychain.cpp.o)) was built for newer iOS version (12.0) than being linked (11.0)

* Measure:
Set deployment target to 11.0

* Incorporation into USC:
Once merged, set publish for Jenkins build -> automatically published into artifactory